### PR TITLE
feat: update config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,7 +110,7 @@
 		"no-magic-numbers": [
 			"warn",
 			{
-			    "ignore": [0, 1, 2],
+				"ignore": [0, 1, 2],
 				"ignoreArrayIndexes": true,
 				"enforceConst": true
 			}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"parserOptions": {
-		"ecmaVersion": 2018
+		"ecmaVersion": 2022
 	},
 	"env": {
 		"node": true,
@@ -43,6 +43,7 @@
 		"no-unreachable": "error",
 		"no-unsafe-finally": "error",
 		"no-unsafe-negation": "error",
+		"no-unsafe-optional-chaining": "error",
 		"require-atomic-updates": "error",
 		"use-isnan": "error",
 		"valid-typeof": "error",
@@ -109,6 +110,7 @@
 		"no-magic-numbers": [
 			"warn",
 			{
+			        "ignore": [0, 1, 2],
 				"ignoreArrayIndexes": true,
 				"enforceConst": true
 			}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,7 +110,7 @@
 		"no-magic-numbers": [
 			"warn",
 			{
-			        "ignore": [0, 1, 2],
+			    "ignore": [0, 1, 2],
 				"ignoreArrayIndexes": true,
 				"enforceConst": true
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-raven",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Very strict ESLint config to make code consistent and more beautiful, that I use myself.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR:
- sets `parserOptions.ecmaVersion` to `2022` (latest as of the date of this pr) to add support for newly added features to ES2022
- adds the rule [`no-unsafe-optional-chaining`](https://eslint.org/docs/rules/no-unsafe-optional-chaining)
- updates the rule [`no-magic-numbers`](https://eslint.org/docs/rules/no-magic-numbers) by adding the `ignore` field to ignore numbers 0, 1, 2